### PR TITLE
fixed 'const not supported in strict mode'

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,25 +1,26 @@
 #!/usr/bin/env node
 /* eslint-disable no-mixed-spaces-and-tabs */
 'use strict';
-const updateNotifier = require('update-notifier');
-const meow = require('meow');
-const trash = require('trash');
+var updateNotifier = require('update-notifier');
+var meow = require('meow');
+var trash = require('trash');
 
-const cli = meow(`
-	Usage
-	  $ trash <path> [...]
-
-	Example
-	  $ trash unicorn.png rainbow.png
-`, {
-	string: ['_']
+var cli = meow([
+  'Usage',
+  '  $ trash <path> [...]',
+  'Example',
+  '  $ trash unicorn.png rainbow.png'
+].join('\n'), {
+  string: ['_']
 });
 
-updateNotifier({pkg: cli.pkg}).notify();
+updateNotifier({
+  pkg: cli.pkg
+}).notify();
 
 if (cli.input.length === 0) {
-	console.error('Specify at least one path');
-	process.exit(1);
+  console.error('Specify at least one path');
+  process.exit(1);
 }
 
 trash(cli.input);


### PR DESCRIPTION
```
/usr/local/lib/node_modules/trash-cli/cli.js:4
const updateNotifier = require('update-notifier');
^^^^^
SyntaxError: Use of const in strict mode.
    at exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:443:25)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3
```