### PR TITLE
Ignore rm flags

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -12,7 +12,9 @@ const cli = meow(`
 	  $ trash unicorn.png rainbow.png
 	  $ trash '*.png' '!unicorn.png'
 `, {
-	string: ['_']
+	string: ['_'],
+	// ignore all flags of `rm` program
+	boolean: ['r', 'f', 'i', 'd', 'P', 'R', 'v', 'W']
 });
 
 updateNotifier({pkg: cli.pkg}).notify();

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ $ trash --help
 
 ## Tip
 
-Add `alias t=trash` to your `.zshrc`/`.bashrc` to reduce typing: `$ t unicorn.png`.
+Add `alias rm=trash` to your `.zshrc`/`.bashrc` to reduce typing & safely trash files: `$ rm unicorn.png`.
 
 
 ## [FAQ](https://github.com/sindresorhus/trash#faq)

--- a/test.js
+++ b/test.js
@@ -3,8 +3,14 @@ import tempWrite from 'temp-write';
 import pathExists from 'path-exists';
 import execa from 'execa';
 
-test(async t => {
+test('trash file', async t => {
 	const filename = tempWrite.sync('foo');
 	await execa('./cli.js', [filename]);
+	t.false(pathExists.sync(filename));
+});
+
+test('ignore rm flags', async t => {
+	const filename = tempWrite.sync('foo');
+	await execa('./cli.js', ['-rf', filename]);
 	t.false(pathExists.sync(filename));
 });


### PR DESCRIPTION
I tried to get myself used to `trash ...`, but I just getting back to `rm -rf` when removing directories. I tried `alias rm=trash`, but `trash` fails when `rm` flags are used.

This PR adds all `rm` flags, so that `meow` recognizes them as boolean options and `cli.input` does not contain them.

That way, I can happily and safely `rm -rf whatever`.